### PR TITLE
Version updates

### DIFF
--- a/src/MimeDetective(Tests).Vb/MimeDetective(Tests).Vb.vbproj
+++ b/src/MimeDetective(Tests).Vb/MimeDetective(Tests).Vb.vbproj
@@ -2,7 +2,7 @@
   <Import Project="..\__Shared\Shared.props" Label="Shared" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <RootNamespace>MimeDetective.Tests.Vb</RootNamespace>
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>

--- a/src/MimeDetective(Tests).Vb/MimeDetective(Tests).Vb.vbproj
+++ b/src/MimeDetective(Tests).Vb/MimeDetective(Tests).Vb.vbproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MimeDetective(Tests)/MimeDetective(Tests).csproj
+++ b/src/MimeDetective(Tests)/MimeDetective(Tests).csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MimeDetective.Definitions(Generator)/MimeDetective.Definitions(Generator).csproj
+++ b/src/MimeDetective.Definitions(Generator)/MimeDetective.Definitions(Generator).csproj
@@ -11,8 +11,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MimeDetective/MimeDetective.csproj
+++ b/src/MimeDetective/MimeDetective.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-	<PackageReference Include="System.Text.Json" Version="8.0.3" />
+	<PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/__Shared/Shared.props
+++ b/src/__Shared/Shared.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <DebugType>full</DebugType>
     <LangVersion>latest</LangVersion>
     <nullable>enable</nullable>


### PR DESCRIPTION
[.NET 7](https://devblogs.microsoft.com/dotnet/dotnet-7-end-of-support/) and [.NET Framework 4.6.1](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/) are no longer supported by Microsoft.

This also updates packages, including a fix for `System.Text.Json` [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).