### PR TITLE
Add support for .NET 9.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>IDE1006</NoWarn>
     <NeutralLanguage>en</NeutralLanguage>
-    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/MimeDetective(Tests)/MimeDetective(Tests).csproj
+++ b/src/MimeDetective(Tests)/MimeDetective(Tests).csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>MimeDetective.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>

--- a/src/MimeDetective.Benchmark/MimeDetective.Benchmark.csproj
+++ b/src/MimeDetective.Benchmark/MimeDetective.Benchmark.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/MimeDetective.Definitions(Generator)/MimeDetective.Definitions(Generator).csproj
+++ b/src/MimeDetective.Definitions(Generator)/MimeDetective.Definitions(Generator).csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>MimeDetective.Definitions.Generator</RootNamespace>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/Samples/MimeDetective.Console.AOT/MimeDetective.Console.AOT.csproj
+++ b/src/Samples/MimeDetective.Console.AOT/MimeDetective.Console.AOT.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>


### PR DESCRIPTION
Modifications in Directory.Build.props add support for the net9.0 framework and update the AOT compatibility condition to include net9.0. The following project files have been updated to target net9.0 in addition to existing frameworks:
- MimeDetective(Tests).csproj
- MimeDetective.Benchmark.csproj
- MimeDetective.Definitions(Generator).csproj
- MimeDetective.Console.AOT.csproj

These changes allow projects to leverage .NET 9.0 features while maintaining compatibility with previous versions.