### PR TITLE
Update MimeType for MP3

### DIFF
--- a/src/MimeDetective/Definitions/Default/FileTypes/Default.FileTypes.Audio.cs
+++ b/src/MimeDetective/Definitions/Default/FileTypes/Default.FileTypes.Audio.cs
@@ -90,7 +90,7 @@ namespace MimeDetective.Definitions {
                         new() {
                             File = new() {
                                 Extensions = ["mp3"],
-                                MimeType = "audio/mpeg3",
+                                MimeType = "audio/mpeg",
                                 Categories = [
                                     Category.Compressed,
                                     Category.Lossy,
@@ -110,7 +110,7 @@ namespace MimeDetective.Definitions {
                         new() {
                             File = new() {
                                 Extensions = ["mp3"],
-                                MimeType = "audio/mpeg3",
+                                MimeType = "audio/mpeg",
                                 Categories = [
                                     Category.Compressed,
                                     Category.Lossy,


### PR DESCRIPTION
# Summary
The `MimeType` for MP3 file should be `audio/mpeg` instead of `audio/mpeg3`.
`audio/mpeg3` is not a valid mime type base on following standards:
[[RFC3003](https://www.iana.org/go/rfc3003)] [[IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)]

# What's changed
Replace all `audio/mpeg3` with `audio/mpeg`.